### PR TITLE
add r packages to conda env

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,6 @@ We recommend using a conda environment to run the Python and R code.
 ```
 conda create -n sfds #Creates the conda environment named sfds.
 conda activate sfds #Activates the environment we created.
-conda env update -n sfds -f environment.yml #Updates the depencies of the environment using the environment.yml file.
+conda env update -n sfds -f environment.yml #Updates the depencies of the environment from environment.yml 
 ```
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ conda activate sfds #Activate the environment we created.
 conda env update -n sfds -f environment.yml #Update the depencies of the environment from environment.yml 
 ```
 
-The full list of Python and R dependencies from the environment.yml file:
+The full list of Python and R dependencies from the [environment.yml](environment.yml) file:
 
 ```
 python

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<style> table { border: 0px; } td { border: 0px; vertical-align: top; } .inner { max-width: 800px; } b { font-weight: bold; }</style>
 ![Python](https://github.com/gedeck/dmba/actions/workflows/build.yml/badge.svg)
 
 # Code repository
@@ -149,11 +148,13 @@ Excecute the notebooks in Binder:
 - The code repository for the first edition is at: <a href="https://github.com/andrewgbruce/statistics-for-data-scientists">https://github.com/andrewgbruce/statistics-for-data-scientists</a>
 
 
-# Setup R and Python environments
+# Setup of R and Python environments
 
-We recommend to use a conda environment to run the Python and R code.
+We recommend using a conda environment to run the Python and R code.
+
 ```
-conda create -n sfds
-conda activate sfds
-conda env update -n sfds -f environment.yml
+conda create -n sfds #Creates the conda environment named sfds.
+conda activate sfds #Activates the environment we created.
+conda env update -n sfds -f environment.yml #Updates the depencies of the environment using the information from the environment.yml file.
 ```
+

--- a/README.md
+++ b/README.md
@@ -155,6 +155,6 @@ We recommend using a conda environment to run the Python and R code.
 ```
 conda create -n sfds #Creates the conda environment named sfds.
 conda activate sfds #Activates the environment we created.
-conda env update -n sfds -f environment.yml #Updates the depencies of the environment using the information from the environment.yml file.
+conda env update -n sfds -f environment.yml #Updates the depencies of the environment using the environment.yml file.
 ```
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ Excecute the notebooks in Binder:
 We recommend using a conda environment to run the Python and R code.
 
 ```
-conda create -n sfds #Creates the conda environment named sfds.
-conda activate sfds #Activates the environment we created.
-conda env update -n sfds -f environment.yml #Updates the depencies of the environment from environment.yml 
+conda create -n sfds #Create the conda environment named sfds.
+conda activate sfds #Activate the environment we created.
+conda env update -n sfds -f environment.yml #Update the depencies of the environment from environment.yml 
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,30 +150,8 @@ Excecute the notebooks in Binder:
 
 
 # Setup R and Python environments
-## R
-Run the following commands in R to install all required packages
-```
-if (!require(vioplot)) install.packages('vioplot')
-if (!require(corrplot)) install.packages('corrplot')
-if (!require(gmodels)) install.packages('gmodels')
-if (!require(matrixStats)) install.packages('matrixStats')
 
-if (!require(lmPerm)) install.packages('lmPerm')
-if (!require(pwr)) install.packages('pwr')
-
-if (!require(FNN)) install.packages('FNN')
-if (!require(klaR)) install.packages('klaR')
-if (!require(DMwR)) install.packages('DMwR')
-
-if (!require(xgboost)) install.packages('xgboost')
-
-if (!require(ellipse)) install.packages('ellipse')
-if (!require(mclust)) install.packages('mclust')
-if (!require(ca)) install.packages('ca')
-```
-
-## Python
-We recommend to use a conda environment to run the Python code.
+We recommend to use a conda environment to run the Python and R code.
 ```
 conda create -n sfds python
 conda activate sfds

--- a/README.md
+++ b/README.md
@@ -158,3 +158,38 @@ conda activate sfds #Activate the environment we created.
 conda env update -n sfds -f environment.yml #Update the depencies of the environment from environment.yml 
 ```
 
+The full list of Python and R dependencies from the environment.yml file:
+
+```
+python
+jupyter
+pandas
+matplotlib
+scipy
+statsmodels
+wquantiles
+seaborn
+scikit-learn
+pygam
+dmba
+pydotplus
+imbalanced-learn
+prince
+xgboost
+graphviz
+r-essentials
+r-base
+r-vioplot
+r-corrplot
+r-gmodels
+r-matrixstats
+r-lmperm
+r-pwr
+r-fnn
+r-klar
+r-dmwr
+r-xgboost
+r-ellipse
+r-mclust
+r-ca
+```

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Excecute the notebooks in Binder:
 
 We recommend to use a conda environment to run the Python and R code.
 ```
-conda create -n sfds python
+conda create -n sfds python r-essentials r-base
 conda activate sfds
 conda env update -n sfds -f environment.yml
 ```

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Excecute the notebooks in Binder:
 
 We recommend to use a conda environment to run the Python and R code.
 ```
-conda create -n sfds python r-essentials r-base
+conda create -n sfds
 conda activate sfds
 conda env update -n sfds -f environment.yml
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -18,3 +18,16 @@ dependencies:
 - prince
 - xgboost
 - graphviz
+- r-vioplot
+- r-corrplot
+- r-gmodels
+- r-matrixstats
+- r-lmperm
+- r-pwr
+- r-fnn
+- r-klar
+- r-dmwr
+- r-xgboost
+- r-ellipse
+- r-mclust
+- r-ca

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,8 @@ dependencies:
 - prince
 - xgboost
 - graphviz
+- r-essentials
+- r-base
 - r-vioplot
 - r-corrplot
 - r-gmodels


### PR DESCRIPTION
This PR is to reduce the amount of software a user would have to install and prevent dependency conflicts on a user's machine if they used conda to manage r environments [Issue 40 for Reference](https://github.com/gedeck/practical-statistics-for-data-scientists/issues/40).

I have decided to exclude the[ conda-forge rstudio-desktop package](https://anaconda.org/conda-forge/rstudio-desktop) until I get an answer from Posit (formerly RStudio) on what repository of RStudio they manage in the conda / Anaconda ecosystem.

Closes #40 